### PR TITLE
Fixing bad indentation of env variables under the pr_build service

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -85,14 +85,14 @@ services:
             $text: pipelinePR.yml
           env:
             GIT_REPO: repo
-          CF_APP_NAME: '{{form.pipeline.parameters.app-name}}'
-          REGISTRY_REGION_ID: '{{form.pipeline.parameters.registry-region}}'
-          REGISTRY_NAMESPACE: '{{form.pipeline.parameters.registry-namespace}}'
-          API_KEY: '{{form.pipeline.parameters.api-key}}'
-          PROD_REGION_ID: '{{form.pipeline.parameters.prod-region}}'
-          PROD_RESOURCE_GROUP: '{{form.pipeline.parameters.prod-resource-group}}'
-          PROD_CLUSTER_NAME: '{{form.pipeline.parameters.prod-cluster-name}}'
-          PROD_CLUSTER_NAMESPACE: '{{form.pipeline.parameters.prod-cluster-namespace}}'
+            CF_APP_NAME: '{{form.pipeline.parameters.app-name}}'
+            REGISTRY_REGION_ID: '{{form.pipeline.parameters.registry-region}}'
+            REGISTRY_NAMESPACE: '{{form.pipeline.parameters.registry-namespace}}'
+            API_KEY: '{{form.pipeline.parameters.api-key}}'
+            PROD_REGION_ID: '{{form.pipeline.parameters.prod-region}}'
+            PROD_RESOURCE_GROUP: '{{form.pipeline.parameters.prod-resource-group}}'
+            PROD_CLUSTER_NAME: '{{form.pipeline.parameters.prod-cluster-name}}'
+            PROD_CLUSTER_NAMESPACE: '{{form.pipeline.parameters.prod-cluster-namespace}}'
         execute: true
   webide:
     service_id: orion


### PR DESCRIPTION
Fixing bad indentation of env variables under the pr_build service